### PR TITLE
Python docker-image version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ docker-debug: docker-check
 	$(ONL)/docker/tools/onlbuilder $(BUILDER_OPTS) $(VOLUMES_OPTS) -c tools/debug.sh
 
 builder:
-	docker pull --platform=linux/amd64 python:3-buster
-	docker tag python:3-buster python:3-buster-amd64
+	docker pull --platform=linux/amd64 python:3.10-buster
+	docker tag python:3.10-buster python:3-buster-amd64
 	cd docker/images/builder && docker build -t $(GOLDSTONE_BUILDER_IMAGE) .
 
 docker: docker-check

--- a/packages/base/amd64/usonic/builds/bcmd/Dockerfile
+++ b/packages/base/amd64/usonic/builds/bcmd/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1.3
 
-FROM python:3-slim AS builder
+FROM python:3.10-slim AS builder
 
 RUN pip install --upgrade pip
 RUN pip install wheel grpcio-tools grpclib
 RUN --mount=type=bind,target=/src,rw cd /src && python -m grpc_tools.protoc -Iproto --python_out=. --python_grpc_out=. ./proto/bcmd/bcmd.proto && mkdir /dist && pip wheel . -w /dist && find /dist
 
-FROM python:3-slim
+FROM python:3.10-slim
 
 ADD https://sonicstorage.blob.core.windows.net/packages/20190307/bcmcmd?sv=2015-04-05&sr=b&sig=sUdbU7oVbh5exbXXHVL5TDFBTWDDBASHeJ8Cp0B0TIc%3D&se=2038-05-06T22%3A34%3A19Z&sp=r /usr/bin/bcmcmd
 RUN chmod +x /usr/bin/bcmcmd

--- a/packages/base/any/python3.10/builds/Makefile
+++ b/packages/base/any/python3.10/builds/Makefile
@@ -1,4 +1,4 @@
-IMAGE_NAME ?= python:3-slim-buster
+IMAGE_NAME ?= python:3.10-slim-buster
 
 all: python pip python3.10 libpython3.10.so.1.0
 


### PR DESCRIPTION
The latest python:`3-buster` image has python3.11, so using tag `3.10-buster` to use python3.10