### PR TITLE
south-ocnos: defined package and added service

### DIFF
--- a/packages/base/amd64/mgmt/builds/templates/kustomization.yaml
+++ b/packages/base/amd64/mgmt/builds/templates/kustomization.yaml
@@ -6,3 +6,4 @@ patches:
 - south-onlp.yaml
 - south-sonic.yaml
 - south-tai.yaml
+- south-ocnos.yaml

--- a/packages/base/amd64/mgmt/builds/templates/south-ocnos.yaml
+++ b/packages/base/amd64/mgmt/builds/templates/south-ocnos.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: south-ocnos
+spec:
+    template:
+        spec:
+            containers:
+            - name: ocnos
+              image: MGMT_IMAGE_REPO/south-ocnos:IMAGE_TAG

--- a/packages/base/any/mgmt/APKG.yml
+++ b/packages/base/any/mgmt/APKG.yml
@@ -118,5 +118,7 @@ packages:
         $X1/packages/base/any/mgmt/builds/units/gs-south-onlp.service: /etc/systemd/system/
         $X1/packages/base/any/mgmt/builds/units/gs-south-onlp-yang.service: /etc/systemd/system/
         $X1/packages/base/any/mgmt/builds/units/gs-north-notif.service: /etc/systemd/system/
+        $X1/packages/base/any/mgmt/builds/units/gs-south-ocnos.service: /etc/systemd/system/
+        $X1/packages/base/any/mgmt/builds/units/gs-south-ocnos-yang.service: /etc/systemd/system/
     after-install: $X1/packages/base/any/mgmt/gsmgmt-after-install.sh
     before-remove: $X1/packages/base/any/mgmt/gsmgmt-before-remove.sh

--- a/packages/base/any/mgmt/builds/Makefile
+++ b/packages/base/any/mgmt/builds/Makefile
@@ -13,7 +13,7 @@ KUBECTL_IMAGE ?= lachlanevenson/k8s-kubectl:latest # multi-arch image
 ifeq ($(ARCH), arm64)
     IMAGES += south-gearbox south-dpll
 else ifeq ($(ARCH), amd64)
-    IMAGES += south-sonic
+    IMAGES += south-sonic south-ocnos
 endif
 
 MGMT_IMAGES ?= $(addsuffix :$(IMAGE_TAG),$(addprefix $(GS_MGMT_IMAGE_REPO)/,$(IMAGES)))

--- a/packages/base/any/mgmt/builds/gs-mgmt.py
+++ b/packages/base/any/mgmt/builds/gs-mgmt.py
@@ -12,6 +12,7 @@ APPS = [
     "north-snmp",
     "north-gnmi",
     "south-sonic",
+    "south-ocnos",
     "south-gearbox",
     "south-dpll",
     "south-tai",

--- a/packages/base/any/mgmt/builds/manifests/kustomization.yaml
+++ b/packages/base/any/mgmt/builds/manifests/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - south-onlp.yaml
 - south-sonic.yaml
 - south-tai.yaml
+- south-ocnos.yaml

--- a/packages/base/any/mgmt/builds/manifests/south-ocnos.yaml
+++ b/packages/base/any/mgmt/builds/manifests/south-ocnos.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocnos-config
+  labels:
+      gs-mgmt: south-ocnos
+data:
+  conf.user: "ocnos"
+  conf.pass: "ocnos"
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+    name: south-ocnos
+    labels:
+        app: gs-mgmt
+        gs-mgmt: south-ocnos
+spec:
+    selector:
+        matchLabels:
+            app: south-ocnos
+    template:
+        metadata:
+            labels:
+                app: south-ocnos
+        spec:
+            containers:
+            - name: ocnos
+              image: ghcr.io/oopt-goldstone/mgmt/south-ocnos:latest
+              imagePullPolicy: Never
+              command: ['gssouthd-ocnos']
+              args: ['--verbose', '--host', '$(OCNOS_CLUSTER_IP_SERVICE_HOST)', '--port', '$(OCNOS_CLUSTER_IP_SERVICE_PORT)', '--username', '$(USERNAME)', '--password', '$(PASSWORD)']
+              env:
+              - name: USERNAME
+                valueFrom:
+                  configMapKeyRef:
+                    name: ocnos-config
+                    key: conf.user
+              - name: PASSWORD
+                valueFrom:
+                  configMapKeyRef:
+                    name: ocnos-config
+                    key: conf.pass
+              volumeMounts:
+              - name: shm
+                mountPath: /dev/shm
+              - name: sysrepo
+                mountPath: /var/lib/sysrepo
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: liveness-port
+                failureThreshold: 2
+                periodSeconds: 10
+              startupProbe:
+                httpGet:
+                  path: /healthz
+                  port: liveness-port
+                failureThreshold: 120
+                periodSeconds: 1
+              ports:
+              - name: liveness-port
+                containerPort: 8080
+            volumes:
+            - name: shm
+              hostPath:
+                  path: /dev/shm
+            - name: sysrepo
+              hostPath:
+                  path: /var/lib/sysrepo

--- a/packages/base/any/mgmt/builds/units/gs-south-ocnos-yang.service
+++ b/packages/base/any/mgmt/builds/units/gs-south-ocnos-yang.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Goldstone Management South OcNOS Daemon YANG model setup
+Before=gs-yang.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/gs-yang.py --install south-ocnos
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/base/any/mgmt/builds/units/gs-south-ocnos.service
+++ b/packages/base/any/mgmt/builds/units/gs-south-ocnos.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Goldstone Management South OcNOS daemon
+After=gs-yang.service ocnos.service
+Requires=gs-yang.service ocnos.service
+PartOf=gs-mgmt-south.target gs-mgmt.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sh -c 'while [ true ]; do ( kubectl get nodes | grep " Ready" ) && exit 0; sleep 1; done'
+ExecStart=/usr/bin/gs-mgmt.py start south-ocnos
+ExecStop=-/usr/bin/gs-mgmt.py stop south-ocnos
+RemainAfterExit=true
+StandardOutput=journal
+
+[Install]
+WantedBy=gs-mgmt-south.target
+Also=gs-south-ocnos-yang.service

--- a/packages/platforms/accton/x86-64/as7316-26xb/goldstone-platform-config/builds/init.sh
+++ b/packages/platforms/accton/x86-64/as7316-26xb/goldstone-platform-config/builds/init.sh
@@ -5,6 +5,7 @@ set -eux
 systemctl disable usonic
 systemctl disable tai
 systemctl disable gs-mgmt-xlate.target
-systemctl disable gs-mgmt-south.target
+systemctl enable gs-mgmt-south.target
 systemctl disable gs-north-gnmi
 systemctl enable ocnos
+systemctl enable gs-south-onlp

--- a/packages/platforms/accton/x86-64/as7316-26xb/goldstone-platform-config/builds/init.sh
+++ b/packages/platforms/accton/x86-64/as7316-26xb/goldstone-platform-config/builds/init.sh
@@ -9,3 +9,4 @@ systemctl enable gs-mgmt-south.target
 systemctl disable gs-north-gnmi
 systemctl enable ocnos
 systemctl enable gs-south-onlp
+systemctl enable gs-south-ocnos

--- a/packages/platforms/accton/x86-64/as7946-30xb/goldstone-platform-config/builds/init.sh
+++ b/packages/platforms/accton/x86-64/as7946-30xb/goldstone-platform-config/builds/init.sh
@@ -5,6 +5,7 @@ set -eux
 systemctl disable usonic
 systemctl disable tai
 systemctl disable gs-mgmt-xlate.target
-systemctl disable gs-mgmt-south.target
+systemctl enable gs-mgmt-south.target
 systemctl disable gs-north-gnmi
 systemctl enable ocnos
+systemctl enable gs-south-onlp

--- a/packages/platforms/accton/x86-64/as7946-30xb/goldstone-platform-config/builds/init.sh
+++ b/packages/platforms/accton/x86-64/as7946-30xb/goldstone-platform-config/builds/init.sh
@@ -9,3 +9,4 @@ systemctl enable gs-mgmt-south.target
 systemctl disable gs-north-gnmi
 systemctl enable ocnos
 systemctl enable gs-south-onlp
+systemctl enable gs-south-ocnos


### PR DESCRIPTION
This PR adds `south-ocnos` package and `gs-south-ocnos` service.
The service depends on `ocnos` service (containerized OcNOS).
So, `gs-south-ocnos` service starts when (after) containerized OcNOS is successfully deployed on k3s.
It also enables `south-onlp` service.

It is currently enabled for as7946-30XB (AGR400) and as7326-26XB (CSR320).
I have checked `south-ocnos` is correctly running by installing built image to actual AGR400 and CSR320 in our development/testing environment.

The simple test log is as follows.
```
root@localhost:~# k get pods // when ocnos is not deployed.
NAME                        READY   STATUS    RESTARTS   AGE
south-onlp-7sttd            1/1     Running   0          163m
svclb-north-netconf-zcg7s   1/1     Running   0          159m
north-netconf-vd2nl         1/1     Running   0          159m
svclb-north-snmp-7mbx7      1/1     Running   0          159m
north-snmp-k7kpc            2/2     Running   0          159m
north-notif-9gskb           1/1     Running   0          159m
system-telemetry-wlkf6      1/1     Running   0          159m
root@localhost:~# systemctl start ocnos // start ocnos service after importing ocnos image.
root@localhost:~# k get pods
NAME                        READY   STATUS    RESTARTS   AGE
south-onlp-7sttd            1/1     Running   0          163m
svclb-north-netconf-zcg7s   1/1     Running   0          159m
north-netconf-vd2nl         1/1     Running   0          159m
svclb-north-snmp-7mbx7      1/1     Running   0          159m
north-snmp-k7kpc            2/2     Running   0          159m
north-notif-9gskb           1/1     Running   0          159m
system-telemetry-wlkf6      1/1     Running   0          159m
ocnos                       1/1     Running   0          10s
root@localhost:~# systemctl start gs-south-ocnos
root@localhost:~# k get po
NAME                        READY   STATUS    RESTARTS      AGE
south-onlp-7sttd            1/1     Running   0             166m
svclb-north-netconf-zcg7s   1/1     Running   0             163m
north-netconf-vd2nl         1/1     Running   0             163m
svclb-north-snmp-7mbx7      1/1     Running   0             163m
north-snmp-k7kpc            2/2     Running   0             163m
north-notif-9gskb           1/1     Running   0             163m
system-telemetry-wlkf6      1/1     Running   0             163m
ocnos                       1/1     Running   0             3m37s
south-ocnos-4rxft           1/1     Running   0             91s
root@localhost:~# systemctl status ocnos
● ocnos.service - OcNOS
   Loaded: loaded (/etc/systemd/system/ocnos.service; enabled; vendor preset: enabled)
   Active: active (exited) since Thu 2019-02-14 12:58:34 UTC; 4min 27s ago
  Process: 22524 ExecStartPre=/bin/sh -c while [ true ]; do ( kubectl get nodes | grep " Ready" ) && exit 0; sleep 1; done (code=exited, status=0/SUCCESS)
  Process: 22544 ExecStart=/usr/bin/ocnos.sh start (code=exited, status=0/SUCCESS)
 Main PID: 22544 (code=exited, status=0/SUCCESS)

Feb 14 12:58:32 localhost ocnos.sh[22544]: + case "$1" in
Feb 14 12:58:32 localhost ocnos.sh[22544]: + start
Feb 14 12:58:32 localhost ocnos.sh[22544]: + kubectl apply -f /var/lib/ocnos/k8s
Feb 14 12:58:32 localhost ocnos.sh[22544]: service/ocnos-cluster-ip created
Feb 14 12:58:32 localhost ocnos.sh[22544]: pod/ocnos created
Feb 14 12:58:32 localhost ocnos.sh[22544]: ++ kubectl get pod -l name=ocnos -o 'jsonpath={.items[*].metadata.name}'
Feb 14 12:58:33 localhost ocnos.sh[22544]: + for pod in $(kubectl get pod -l name=ocnos -o jsonpath='{.items[*].metadata.name}')
Feb 14 12:58:33 localhost ocnos.sh[22544]: + kubectl wait --for=condition=ready pod/ocnos --timeout 5m
Feb 14 12:58:34 localhost ocnos.sh[22544]: pod/ocnos condition met
Feb 14 12:58:34 localhost systemd[1]: Started OcNOS.
root@localhost:~# systemctl status gs-south-ocnos
● gs-south-ocnos.service - Goldstone Management South OcNOS daemon
   Loaded: loaded (/etc/systemd/system/gs-south-ocnos.service; enabled; vendor preset: enabled)
   Active: active (exited) since Thu 2019-02-14 13:01:26 UTC; 1min 41s ago
  Process: 25994 ExecStartPre=/bin/sh -c while [ true ]; do ( kubectl get nodes | grep " Ready" ) && exit 0; sleep 1; done (code=exited, status=0/SUCCESS)
  Process: 26014 ExecStart=/usr/bin/gs-mgmt.py start south-ocnos (code=exited, status=0/SUCCESS)
 Main PID: 26014 (code=exited, status=0/SUCCESS)

Feb 14 13:00:35 localhost systemd[1]: Starting Goldstone Management South OcNOS daemon...
Feb 14 13:00:36 localhost sh[25994]: localhost   Ready    control-plane,master   165m   v1.22.2+k3s-
Feb 14 13:00:38 localhost gs-mgmt.py[26014]: configmap/ocnos-config created
Feb 14 13:00:38 localhost gs-mgmt.py[26014]: daemonset.apps/south-ocnos created
Feb 14 13:01:26 localhost gs-mgmt.py[26014]: pod/south-ocnos-4rxft condition met
Feb 14 13:01:26 localhost systemd[1]: Started Goldstone Management South OcNOS daemon.
```