### PR TITLE
usonic: update container image

### DIFF
--- a/make/mgmt.mk
+++ b/make/mgmt.mk
@@ -3,9 +3,16 @@ GS_MGMT_VERSION ?= v0.8.0
 
 .PHONY: manifests
 
+ifndef X1
+$(error $X1 is not defined)
+endif
+
+GS_MGMT_BASE ?= $(X1)/packages/base/any/mgmt/builds/manifests
+
 manifests:
 	rm -rf manifests && mkdir manifests
 	for file in $(wildcard $(TEMPLATE_DIR)/*.yaml);\
 	do\
 	    sed -e s!IMAGE_TAG!$(IMAGE_TAG)!g -e s!MGMT_IMAGE_REPO!$(GS_MGMT_IMAGE_REPO)!g $$file > manifests/$$(basename $$file);\
 	done
+	cp -r $(GS_MGMT_BASE) manifests/base

--- a/packages/base/amd64/usonic/builds/Makefile
+++ b/packages/base/amd64/usonic/builds/Makefile
@@ -1,4 +1,4 @@
-USONIC_IMAGES ?= docker.io/nlpldev/usonic-cli:latest ghcr.io/microsonic/usonic-debug:201904 docker.io/bitnami/kubectl:latest
+USONIC_IMAGES ?= ghcr.io/oopt-goldstone/usonic-cli:201904 ghcr.io/oopt-goldstone/usonic-debug:201904 docker.io/bitnami/kubectl:latest
 BCMD_IMAGE ?= bcmd:latest
 
 SAI_VERSION := 20220524

--- a/packages/base/amd64/usonic/builds/manifests/cli.yaml
+++ b/packages/base/amd64/usonic/builds/manifests/cli.yaml
@@ -5,9 +5,12 @@ metadata:
 spec:
     containers:
     - name: cli
-      image: docker.io/nlpldev/usonic-cli:latest
+      image: ghcr.io/oopt-goldstone/usonic-cli:201904
       imagePullPolicy: IfNotPresent
-      command: ['sh', '-c', 'sleep 100000']
+      command: ['bash', '-c', 'trap : TERM INT; sleep infinity & wait']
+      env:
+      - name: DEFAULT_DB_HOST
+        value: "redis.default.svc.cluster.local"
       volumeMounts:
       - name: sonic-db-config
         mountPath: /var/run/redis/sonic-db/

--- a/packages/base/amd64/usonic/builds/manifests/redis.yaml
+++ b/packages/base/amd64/usonic/builds/manifests/redis.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
     containers:
     - name: redis
-      image: ghcr.io/microsonic/usonic-debug:201904
+      image: ghcr.io/oopt-goldstone/usonic-debug:201904
       imagePullPolicy: IfNotPresent
       command: ["redis-server", "/etc/redis/redis.conf"]
       volumeMounts:

--- a/packages/base/amd64/usonic/builds/manifests/usonic.yaml
+++ b/packages/base/amd64/usonic/builds/manifests/usonic.yaml
@@ -46,7 +46,7 @@ spec:
             dnsPolicy: ClusterFirstWithHostNet
             initContainers:
             - name: init-loglevel
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['/var/run/start/start.sh']
               volumeMounts:
@@ -56,9 +56,9 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: init-configdb
-              image: docker.io/nlpldev/usonic-cli:latest
+              image: ghcr.io/oopt-goldstone/usonic-cli:201904
               imagePullPolicy: IfNotPresent
-              command: ['sonic-cfggen', '-k', 'dummy', '-p', '/etc/usonic/port_config.ini', '-j', '/etc/sonic/config_db.json', '--write-to-db']
+              command: ['sonic-cfggen', '-s', '/var/run/redis/redis.sock', '-k', 'dummy', '-p', '/etc/usonic/port_config.ini', '-j', '/etc/sonic/config_db.json', '--write-to-db']
               volumeMounts:
               - name: sonic-db-config
                 mountPath: /var/run/redis/sonic-db/
@@ -66,13 +66,15 @@ spec:
                 mountPath: /etc/sonic/
               - name: usonic-config
                 mountPath: /etc/usonic/
+              - name: redis-sock
+                mountPath: /var/run/redis/redis.sock
             - name: complete-init
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['redis-cli', '-h', 'redis.default.svc.cluster.local', '-n', '4', 'SET', 'CONFIG_DB_INITIALIZED', '1']
             containers:
             - name: syncd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['sh', '-c', 'service syslog-ng start && dsserve /usr/bin/syncd -p /etc/sonic/sai.profile -d']
               env:
@@ -100,7 +102,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: orchagent
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['orchagent']
               args: ['-m', '$(GLOBAL_MAC_ADDRESS)']
@@ -263,7 +265,7 @@ spec:
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-bcm', '--timeout=5m']
             containers:
             - name: portsyncd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['portsyncd']
               volumeMounts:
@@ -336,7 +338,7 @@ spec:
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-port', '--timeout=5m']
             containers:
             - name: neighsyncd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['neighsyncd']
               volumeMounts:
@@ -388,7 +390,7 @@ spec:
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-core', '--timeout=5m']
             containers:
             - name: fpmsyncd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['fpmsyncd']
               volumeMounts:
@@ -403,7 +405,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: zebra
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['/usr/lib/frr/zebra', '-A', '127.0.0.1', '-s', '90000000', '-M', 'fpm']
               volumeMounts:
@@ -414,7 +416,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: staticd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['/usr/lib/frr/staticd', '-A', '127.0.0.1']
               volumeMounts:
@@ -425,7 +427,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: bgpd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['/usr/lib/frr/bgpd', '-A', '127.0.0.1']
               volumeMounts:
@@ -477,7 +479,7 @@ spec:
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-port', '--timeout=5m']
             containers:
             - name: teamsyncd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['teamsyncd']
               volumeMounts:
@@ -492,7 +494,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: teammgrd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['teammgrd']
               volumeMounts:
@@ -548,7 +550,7 @@ spec:
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-core', '--timeout=5m']
             containers:
             - name: lldpd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['/usr/sbin/lldpd', '-d', '-I', 'Ethernet*,eth0', '-C', 'eth0']
               volumeMounts:
@@ -563,7 +565,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
                     #            - name: lldpsyncd
-                    #              image: ghcr.io/microsonic/usonic-debug:201904
+                    #              image: ghcr.io/oopt-goldstone/usonic-debug:201904
                     #              imagePullPolicy: IfNotPresent
                     #              command: ['/usr/bin/env', 'python2', '-m', 'lldp_syncd']
                     #              volumeMounts:
@@ -578,7 +580,7 @@ spec:
                     #                capabilities:
                     #                    add: ["NET_ADMIN"]
                     #            - name: lldpmgrd
-                    #              image: ghcr.io/microsonic/usonic-debug:201904
+                    #              image: ghcr.io/oopt-goldstone/usonic-debug:201904
                     #              imagePullPolicy: IfNotPresent
                     #              command: ['/usr/bin/lldpmgrd']
                     #              volumeMounts:
@@ -635,7 +637,7 @@ spec:
               imagePullPolicy: IfNotPresent
               command: ['kubectl', 'wait', '--for=condition=available', 'deploy/usonic-port', '--timeout=5m']
             - name: swssconfig
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['swssconfig']
               volumeMounts:
@@ -643,7 +645,7 @@ spec:
                 mountPath: /var/run/redis/redis.sock
             containers:
             - name: vlanmgrd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['sh', '-c', 'mount -o remount,rw /sys && vlanmgrd']
               volumeMounts:
@@ -654,7 +656,7 @@ spec:
               securityContext:
                 privileged: true
             - name: intfmgrd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['intfmgrd']
               volumeMounts:
@@ -666,7 +668,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: portmgrd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['portmgrd']
               volumeMounts:
@@ -678,7 +680,7 @@ spec:
                 capabilities:
                     add: ["NET_ADMIN"]
             - name: nbrmgrd
-              image: ghcr.io/microsonic/usonic-debug:201904
+              image: ghcr.io/oopt-goldstone/usonic-debug:201904
               imagePullPolicy: IfNotPresent
               command: ['nbrmgrd']
               volumeMounts:

--- a/packages/base/any/mgmt/APKG.yml
+++ b/packages/base/any/mgmt/APKG.yml
@@ -100,7 +100,6 @@ packages:
         builds/mgmt-$ARCH.tar: /var/lib/rancher/k3s/agent/images/
         builds/k8s-$ARCH.tar: /var/lib/rancher/k3s/agent/images/
         builds/manifests:  /var/lib/goldstone/k8s
-        $X1/packages/base/any/mgmt/builds/manifests:  /var/lib/goldstone/k8s/base
         $X1/packages/base/any/mgmt/builds/gs-mgmt.py: /usr/bin/
         $X1/packages/base/any/mgmt/builds/units/gs-mgmt.target: /etc/systemd/system/
         $X1/packages/base/any/mgmt/builds/units/gs-mgmt-south.target: /etc/systemd/system/

--- a/packages/base/any/tai/builds/Dockerfile
+++ b/packages/base/any/tai/builds/Dockerfile
@@ -5,5 +5,4 @@ FROM ${BASE}
 
 ARG TARGETARCH
 
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt,sharing=private \
-    if [ $TARGETARCH = amd64 ]; then apt update && DEBIAN_FRONTEND=noninteractive apt install -qy --no-install-recommends libi2c0; fi
+RUN if [ $TARGETARCH = amd64 ]; then apt update && DEBIAN_FRONTEND=noninteractive apt install -qy --no-install-recommends libi2c0; fi


### PR DESCRIPTION
The usonic repo is moved from https://github.com/microsonic/usonic to https://github.com/oopt-goldstone/usonic.

I [fixed](https://github.com/oopt-goldstone/usonic/actions/runs/5750718729/job/15588054563) the CI of the `oopt-goldstone/usonic` and all container [images](https://github.com/orgs/oopt-goldstone/packages?repo_name=usonic) are now available from ghcr.io/oopt-goldstone.