### PR TITLE
Loading libtai-xxx.so on GFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can download pre-built Goldstone ONIE installer from the [release](https://g
 - make
 - Docker ( version >= 18.09, enable [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) )
   - Enable an execution of different multi-architecture containers by QEMU and binfmt_misc
-    - You can do this by running `docker run --rm --privileged multiarch/qemu-user-static --reset -p`
+    - You can do this by running `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` with administrative priviledge
     - See https://github.com/multiarch/qemu-user-static for details
 - Python
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can download pre-built Goldstone ONIE installer from the [release](https://g
 - make
 - Docker ( version >= 18.09, enable [buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) )
   - Enable an execution of different multi-architecture containers by QEMU and binfmt_misc
-    - You can do this by running `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` with administrative priviledge
+    - You can do this by running `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` with administrative privilege
     - See https://github.com/multiarch/qemu-user-static for details
 - Python
 

--- a/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/cfp2dco.json
+++ b/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/cfp2dco.json
@@ -1,0 +1,5 @@
+{
+    "LDCO40-DO"    : "libtai-ldc.so",
+    "TRB100DAA-01" : "libtai-lumentum.so",
+    "TRB200DAA-01" : "libtai-lumentum.so"
+}

--- a/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/cfp2dco.json
+++ b/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/cfp2dco.json
@@ -1,5 +1,6 @@
 {
-    "LDCO40-DO"    : "libtai-ldc.so",
+    "LDC040-DO"    : "libtai-ldc.so",
+    "LDC041-EO"    : "libtai-ldc.so",
     "TRB100DAA-01" : "libtai-lumentum.so",
     "TRB200DAA-01" : "libtai-lumentum.so"
 }

--- a/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/exec.py
+++ b/packages/platforms/wistron/arm64/wtp-01-c1-00/goldstone-platform-config/builds/tai/mux/exec.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import sys
+import json
 from pathlib import Path
-
 
 def main():
     if len(sys.argv) != 2:
@@ -18,7 +18,10 @@ def main():
         return
 
     dev = arg.split("/")[-1]
-
+    
+    with open(f'/etc/tai/mux/cfp2dco.json') as f:
+        cfp2dco = json.load(f)
+    
     with open(f"/sys/class/cfp2dco/cfp2dco{dev}/part_number") as f:
         try:
             part = f.read().strip()
@@ -28,11 +31,8 @@ def main():
 
         print(f"dev: {dev}, part: {part}", file=sys.stderr)
 
-        if part == "LDC040-DO":
-            print("libtai-ldc.so")
-        elif part == "TRB100DAA-01" or part == "TRB200DAA-01":
-            print("libtai-lumentum.so")
-
+        if part in cfp2dco:
+            print("{}".format(cfp2dco[part]))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Currently I am trying to try a 400G CFP2DCO on Galileo Flex-T, except for libtai-ldc, libtai-lumentum, which are written as standard. In adding new libati-xxx.so, I would like to avoid hard-coding, so I would like to propose the following form of loading the libraries. Please confirm. (and fix typo on README.md)